### PR TITLE
Filter by polygon - Add the capability to filter by user instead of groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Spatial filter - Add the capability to filter the spatial layers data by matching the polygon layer field values with the user login. The behaviour depends on a new configuration option `filter_by_user` for the spatial filter. It will be compatible with LWC >= 3.5.
+
 ## 1.0.2 - 2022-06-28
 
 * Refactor a little the code about access control list

--- a/lizmap_server/lizmap_accesscontrol.py
+++ b/lizmap_server/lizmap_accesscontrol.py
@@ -299,7 +299,12 @@ class LizmapAccessControlFilter(QgsAccessControlFilter):
                     return NO_FEATURES
 
                 # polygon_filter is set, we have a value to filter
-                polygon_filter, _ = filter_polygon_config.subset_sql(groups)
+                # pass the tuple of groups or the tuple of the user
+                # depending on the filter_by_user boolean variable
+                groups_or_user = groups
+                if filter_polygon_config.is_filtered_by_user():
+                    groups_or_user = tuple([user_login])
+                polygon_filter, _ = filter_polygon_config.subset_sql(groups_or_user)
 
         except Exception as e:
             Logger.log_exception(e)

--- a/lizmap_server/lizmap_service.py
+++ b/lizmap_server/lizmap_service.py
@@ -21,6 +21,7 @@ from lizmap_server.core import (
     get_lizmap_groups,
     get_lizmap_layers_config,
     get_lizmap_override_filter,
+    get_lizmap_user_login,
     is_editing_context,
     write_json_response,
 )
@@ -163,8 +164,17 @@ class LizmapService(QgsService):
                 else:
                     # Get Lizmap user groups provided by the request
                     groups = get_lizmap_groups(self.server_iface.requestHandler())
+
                     # polygon_filter is set, we have a value to filter
-                    sql, polygons = filter_polygon_config.subset_sql(groups)
+                    # pass the tuple of groups or the tuple of the user
+                    # depending on the filter_by_user boolean variable
+                    groups_or_user = groups
+                    if filter_polygon_config.is_filtered_by_user():
+                        user_login = get_lizmap_user_login(self.server_iface.requestHandler())
+                        groups_or_user = tuple([user_login])
+
+                    # Get the subset SQL
+                    sql, polygons = filter_polygon_config.subset_sql(groups_or_user)
                     body = {
                         'status': 'success',
                         'filter': sql,


### PR DESCRIPTION
* **Funded by**:  [Valabre](https://www.valabre.com/)
* **Description**:  LWC 3.5 introduced a new feature allowing to filter some layer data spatially based on the authenticated user groups. This PR adds the capability to filter either by the user groups (default) or by the user login. The behaviour depends on a new configuration option `filter_by_user` for the spatial filter.

Corresponding PR in lizmap-plugin: https://github.com/3liz/lizmap-plugin/pull/435