### PR TITLE
Performance - Fix issues preventing to use PostgreSQL to get the ids to filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased
 
 * Add the plugin name when fetching metadata from QGIS server.
+* Fix an issue when the polygon table has a schema or table name which must be enclosed with double quotes.
+* Fix an issue preventing to query the PostgreSQL database to retrieve the ids to filter. Performance could be severely
+  degraded for heavy filtered layers.
 
 ## 1.1.0 - 2022-07-25
 


### PR DESCRIPTION
* **Funded by**: 3liz
* **Description**: Fix some issue preventing to correctly use PostgreSQL queries
  * Add double quote to correctly escape the polygon schema and table names
  * Fix the wrong usage of the variable `use_st_relationship` which always triggered the fallback to the slow QGIS method to get the ids to filter.
