### PR TITLE
Reactivate layerFilterSubsetString and deactivate layerFilterExpression

### DIFF
--- a/lizmap_server/filter_by_polygon.py
+++ b/lizmap_server/filter_by_polygon.py
@@ -31,7 +31,7 @@ CACHE_MAX_SIZE = 100
 # 1 = 0 results in a "false" in OGR/PostGIS
 # ET : I didn't find a proper false value in OGR
 NO_FEATURES = '1 = 0'
-ALL_FEATURES = '1 = 1'
+ALL_FEATURES = ''
 
 
 # noinspection PyArgumentList

--- a/lizmap_server/lizmap_accesscontrol.py
+++ b/lizmap_server/lizmap_accesscontrol.py
@@ -2,12 +2,7 @@ __copyright__ = 'Copyright 2021, 3Liz'
 __license__ = 'GPL version 3'
 __email__ = 'info@3liz.org'
 
-from qgis.core import (
-    QgsExpression,
-    QgsMapLayer,
-    QgsProject,
-    QgsVectorLayer,
-)
+from qgis.core import QgsExpression, QgsMapLayer, QgsProject, QgsVectorLayer
 from qgis.server import QgsAccessControlFilter, QgsServerInterface
 
 from lizmap_server.core import (

--- a/lizmap_server/lizmap_accesscontrol.py
+++ b/lizmap_server/lizmap_accesscontrol.py
@@ -37,34 +37,34 @@ class LizmapAccessControlFilter(QgsAccessControlFilter):
 
         self.iface = server_iface
 
-    def layerFilterExpression(self, layer: QgsVectorLayer) -> str:
-        """ Return an additional expression filter """
-        # Disabling Lizmap layer filter expression for QGIS Server <= 3.16.1 and <= 3.10.12
-        # Fix in QGIS Server https://github.com/qgis/QGIS/pull/40556 3.18.0, 3.16.2, 3.10.13
-        if 31013 <= Qgis.QGIS_VERSION_INT < 31099 or 31602 <= Qgis.QGIS_VERSION_INT:
-            Logger.info("Lizmap layerFilterExpression")
-            filter_exp = self.get_lizmap_layer_filter(layer, filter_type=FilterType.QgisExpression)
-            if filter_exp:
-                return filter_exp
-
-            return super().layerFilterExpression(layer)
-
-        message = (
-            "Lizmap layerFilterExpression disabled, you should consider upgrading QGIS Server to >= "
-            "3.10.13 or >= 3.16.2")
-        Logger.critical(message)
-        return ALL_FEATURES
-
-    # def layerFilterSubsetString(self, layer: QgsVectorLayer) -> str:
-    #     """ Return an additional subset string (typically SQL) filter """
-    #     Logger.info("Lizmap layerFilterSubsetString")
-    #     # We should have a safe SQL query.
-    #     # QGIS Server can consider the ST_Intersect/ST_Contains not safe regarding SQL injection.
-    #     filter_exp = self.get_lizmap_layer_filter(layer, filter_type=FilterType.SafeSqlQuery)
-    #     if filter_exp:
-    #         return filter_exp
+    # def layerFilterExpression(self, layer: QgsVectorLayer) -> str:
+    #     """ Return an additional expression filter """
+    #     # Disabling Lizmap layer filter expression for QGIS Server <= 3.16.1 and <= 3.10.12
+    #     # Fix in QGIS Server https://github.com/qgis/QGIS/pull/40556 3.18.0, 3.16.2, 3.10.13
+    #     if 31013 <= Qgis.QGIS_VERSION_INT < 31099 or 31602 <= Qgis.QGIS_VERSION_INT:
+    #         Logger.info("Lizmap layerFilterExpression")
+    #         filter_exp = self.get_lizmap_layer_filter(layer, filter_type=FilterType.QgisExpression)
+    #         if filter_exp:
+    #             return filter_exp
     #
-    #     return super().layerFilterSubsetString(layer)
+    #         return super().layerFilterExpression(layer)
+    #
+    #     message = (
+    #         "Lizmap layerFilterExpression disabled, you should consider upgrading QGIS Server to >= "
+    #         "3.10.13 or >= 3.16.2")
+    #     Logger.critical(message)
+    #     return ALL_FEATURES
+
+    def layerFilterSubsetString(self, layer: QgsVectorLayer) -> str:
+        """ Return an additional subset string (typically SQL) filter """
+        Logger.info("Lizmap layerFilterSubsetString")
+        # We should have a safe SQL query.
+        # QGIS Server can consider the ST_Intersect/ST_Contains not safe regarding SQL injection.
+        filter_exp = self.get_lizmap_layer_filter(layer, filter_type=FilterType.SafeSqlQuery)
+        if filter_exp:
+            return filter_exp
+
+        return super().layerFilterSubsetString(layer)
 
     def layerPermissions(self, layer: QgsMapLayer) -> QgsAccessControlFilter.LayerPermissions:
         """ Return the layer rights """

--- a/lizmap_server/lizmap_accesscontrol.py
+++ b/lizmap_server/lizmap_accesscontrol.py
@@ -3,7 +3,6 @@ __license__ = 'GPL version 3'
 __email__ = 'info@3liz.org'
 
 from qgis.core import (
-    Qgis,
     QgsExpression,
     QgsMapLayer,
     QgsProject,

--- a/test/test_filter_by_polygon.py
+++ b/test/test_filter_by_polygon.py
@@ -168,7 +168,7 @@ class TestFilterByPolygon(unittest.TestCase):
 
         groups = ('admins',)
         subset, ewkt = config.subset_sql(groups)
-        self.assertEqual('1 = 1', subset)
+        self.assertEqual('', subset)
         self.assertEqual('', ewkt)
 
         config = FilterByPolygon(json, points, editing=True)


### PR DESCRIPTION
Because of `QgsAccessControl` stored filter expressions with resolveFilterFeatures used in WMS and does not clear filter expressions cached at the end of request.

Because of `QgsFeatureRequest` could not be `FilterExpression` and `FilterFids`, `QgsAccessControl` filter expressions should not be apply to QgsFeatureRequest when it's type is `FilterFids`.

Lizmap cannot use filter expressions and has to use filter subsetstring.
