### PR TITLE
GetLegendGraphic JSON: Add expression for QGIS >= 3.26

### DIFF
--- a/lizmap_server/get_legend_graphic.py
+++ b/lizmap_server/get_legend_graphic.py
@@ -7,7 +7,7 @@ __copyright__ = 'Copyright 2022, Gis3w'
 
 import json
 
-from qgis.core import QgsProject
+from qgis.core import Qgis, QgsProject
 from qgis.server import QgsServerFilter
 
 from lizmap_server.core import find_vector_layer
@@ -82,6 +82,8 @@ class GetLegendGraphicFilter(QgsServerFilter):
                         'parentRuleKey': item.parentRuleKey(),
                         'scaleMaxDenom': item.scaleMaxDenom(),
                         'scaleMinDenom': item.scaleMinDenom(),
+                        # TODO simplify when QGIS 3.28 will be the minimum version
+                        'expression': renderer.legendKeyToExpression(item.ruleKey(), layer) if Qgis.QGIS_VERSION_INT > 32600 else '',
                     } for item in renderer.legendSymbolItems()
                 }
 
@@ -104,6 +106,7 @@ class GetLegendGraphicFilter(QgsServerFilter):
                         if 'scaleMinDenom' not in symbol and category['scaleMinDenom'] > 0:
                             symbol['scaleMinDenom'] = category['scaleMinDenom']
 
+                        symbol['expression'] = category['expression']
                     except (IndexError, KeyError):
                         pass
 

--- a/test/test_legend.py
+++ b/test/test_legend.py
@@ -2,6 +2,8 @@ import logging
 
 from test.utils import _build_query_string, _check_request
 
+from qgis.core import Qgis
+
 LOGGER = logging.getLogger('server')
 
 __copyright__ = 'Copyright 2023, 3Liz'
@@ -76,5 +78,7 @@ def test_simple_rule_based(client):
     assert symbols[0]['parentRuleKey'] == '{9322759d-05f9-48ac-8947-3137d44d1832}', symbols[0]['parentRuleKey']
     assert 'scaleMaxDenom' not in symbols[0], symbols[0]['scaleMaxDenom']
     assert 'scaleMinDenom' not in symbols[0], symbols[0]['scaleMinDenom']
+    expected = ['"NAME_1" = \'Basse-Normandie\'', True] if Qgis.QGIS_VERSION_INT >= 32600 else ''
+    assert symbols[0]['expression'] == expected, symbols[0]['expression']
     assert b['title'] == ''
     assert b['nodes'][0]['title'] == 'rule_based', b['nodes'][0]['title']


### PR DESCRIPTION
* **Funded by**:  3Liz
* **Description**: 
  * The method `legendKeyToExpression` has been added to QGIS version 3.26 to convert vector renderer legend rule keys to equivalent QgsExpression filter https://github.com/qgis/QGIS/commit/793f887dd621acccd0cdbd5364a9e0805c151b09. It is part of: Add a "Select Features" action to the right click menu on legend class symbols https://github.com/qgis/QGIS/pull/47811
