### PR TITLE
GetFeatureInfo - The XML can be a BoundingBox item and not a Layer item

### DIFF
--- a/lizmap_server/get_feature_info.py
+++ b/lizmap_server/get_feature_info.py
@@ -50,6 +50,11 @@ class GetFeatureInfoFilter(QgsServerFilter):
         """ Edit the XML GetFeatureInfo by adding a maptip for a given layer and feature ID. """
         root = ET.fromstring(string)
         for layer in root:
+
+            if layer.tag.upper() != 'LAYER':
+                # The XML can be <BoundingBox />
+                continue
+
             if layer.attrib['name'] != layer_name:
                 continue
 

--- a/test/test_server_core.py
+++ b/test/test_server_core.py
@@ -202,6 +202,7 @@ class TestServerCore(unittest.TestCase):
     def test_edit_xml_get_feature_info_with_maptip(self):
         """ Test to edit a GetFeatureInfo xml with maptip. """
         string = '''<GetFeatureInfoResponse>
+         <BoundingBox minx="0" maxy="1" maxx="1" CRS="EPSG:2154" miny="0"/>
          <Layer name="qgis_popup">
           <Feature id="1">
            <Attribute name="OBJECTID" value="2662"/>
@@ -219,6 +220,7 @@ class TestServerCore(unittest.TestCase):
         response = GetFeatureInfoFilter.append_maptip(string, "qgis_popup", 1, "<b>foo</b>")
 
         expected = '''<GetFeatureInfoResponse>
+         <BoundingBox minx="0" maxy="1" maxx="1" CRS="EPSG:2154" miny="0"/>
          <Layer name="qgis_popup">
           <Feature id="1">
            <Attribute name="OBJECTID" value="2662" />


### PR DESCRIPTION
Related to support 2700

```
pmaster_test_qgis  | <GetFeatureInfoResponse>
lizmapmaster_test_qgis  |  <BoundingBox minx="695509.79609185" maxy="6321556.88189175" maxx="695509.79609185" CRS="EPSG:2154" miny="6321556.88189175"/>
lizmapmaster_test_qgis  |  <Layer name="dnd_form_geom">
lizmapmaster_test_qgis  |   <Feature id="1">
lizmapmaster_test_qgis  |    <Attribute name="id" value="1"/>
lizmapmaster_test_qgis  |    <Attribute name="field_in_dnd_form" value="test_geom"/>
lizmapmaster_test_qgis  |    <Attribute name="field_not_in_dnd_form" value="test_geom"/>
lizmapmaster_test_qgis  |    <BoundingBox minx="695509.79609185" maxy="6321556.88189175" maxx="695509.79609185" CRS="EPSG:2154" miny="6321556.88189175"/>
lizmapmaster_test_qgis  |    <Attribute name="geometry" value="Point (695509.79609185 6321556.88189175)" type="derived"/>
lizmapmaster_test_qgis  |   </Feature>
lizmapmaster_test_qgis  |  </Layer>
lizmapmaster_test_qgis  | </GetFeatureInfoResponse>
```

@mdouchin I have the display of DND tabs in the attribute table

![image](https://github.com/3liz/qgis-lizmap-server-plugin/assets/1609292/7233ea4a-3cbf-49fe-ae33-55e2804be54c)
