### PR TITLE
[Feature] Extending replaceExpressionText Request with ALL features and GeoJSON format

### DIFF
--- a/test/test_expression_service_replaceexpressiontext.py
+++ b/test/test_expression_service_replaceexpressiontext.py
@@ -25,7 +25,7 @@ def test_layer_error_unknown_layer(client):
     """ Test Expression replaceExpressionText request with unknown layer. """
     qs = dict(BASE_QUERY)
     qs['LAYER'] = 'UNKNOWN_LAYER'
-    rv = client.get(_build_query_string(dict(BASE_QUERY)), PROJECT_FILE)
+    rv = client.get(_build_query_string(qs), PROJECT_FILE)
     _check_request(rv, http_code=400)
 
 
@@ -33,7 +33,7 @@ def test_string_error(client):
     """ Test Expression replaceExpressionText request without expression. """
     qs = dict(BASE_QUERY)
     qs['LAYER'] = 'france_parts'
-    rv = client.get(_build_query_string(dict(BASE_QUERY)), PROJECT_FILE)
+    rv = client.get(_build_query_string(qs), PROJECT_FILE)
     _check_request(rv, http_code=400)
 
 
@@ -41,51 +41,50 @@ def test_features_error(client):
     """  Test Expression replaceExpressionText request with Feature or Features parameter error
     """
     # Make a request
-    qs = f"?SERVICE=EXPRESSION&REQUEST=replaceExpressionText&MAP={PROJECT_FILE}&LAYER=france_parts"
-    qs += "&STRINGS={\"a\":\"%s\", \"b\":\"%s\", \"c\":\"%s\", \"d\":\"%s\"}" % (
+    qs = dict(BASE_QUERY)
+    qs['LAYER'] = 'france_parts'
+    qs['STRINGS'] = "{\"a\":\"%s\", \"b\":\"%s\", \"c\":\"%s\", \"d\":\"%s\"}" % (
         quote('[% 1 %]', safe=''), quote('[% 1 + 1 %]', safe=''), quote('[% prop0 %]', safe=''),
         quote('[% $x %]', safe=''))
-    qs += "&FEATURE={\"type\":\"Feature\", \"geometry\": {\"type\": \"Point\", \"coordinates\": [102.0, 0.5]}, \"properties\": {\"prop0\": \"value0\"}"
-    rv = client.get(qs, PROJECT_FILE)
-    assert rv.status_code == 400
-    assert rv.headers.get('Content-Type', '').find('application/json') == 0
+    qs['FEATURE'] = "{\"type\":\"Feature\", \"geometry\": {\"type\": \"Point\", \"coordinates\": [102.0, 0.5]}, \"properties\": {\"prop0\": \"value0\"}"
+    rv = client.get(_build_query_string(qs), PROJECT_FILE)
+    _check_request(rv, http_code=400)
 
     # Make a request
-    qs = f"?SERVICE=EXPRESSION&REQUEST=replaceExpressionText&MAP={PROJECT_FILE}&LAYER=france_parts"
-    qs += "&STRINGS={\"a\":\"%s\", \"b\":\"%s\", \"c\":\"%s\", \"d\":\"%s\"}" % (
+    qs = dict(BASE_QUERY)
+    qs['LAYER'] = 'france_parts'
+    qs['STRINGS'] = "{\"a\":\"%s\", \"b\":\"%s\", \"c\":\"%s\", \"d\":\"%s\"}" % (
         quote('[% 1 %]', safe=''), quote('[% 1 + 1 %]', safe=''), quote('[% prop0 %]', safe=''),
         quote('[% $x %]', safe=''))
-    qs += "&FEATURE={\"type\":\"feature\", \"geometry\": {\"type\": \"Point\", \"coordinates\": [102.0, 0.5]}, \"properties\": {\"prop0\": \"value0\"}}"
-    # type feature and not Feature error
-    rv = client.get(qs, PROJECT_FILE)
-    assert rv.status_code == 400
-    assert rv.headers.get('Content-Type', '').find('application/json') == 0
+    qs['FEATURE'] = "{\"type\":\"feature\", \"geometry\": {\"type\": \"Point\", \"coordinates\": [102.0, 0.5]}, \"properties\": {\"prop0\": \"value0\"}}"
+    rv = client.get(_build_query_string(qs), PROJECT_FILE)
+    _check_request(rv, http_code=400)
 
     # Make a request
-    qs = f"?SERVICE=EXPRESSION&REQUEST=replaceExpressionText&MAP={PROJECT_FILE}&LAYER=france_parts"
-    qs += "&STRINGS={\"a\":\"%s\", \"b\":\"%s\", \"c\":\"%s\", \"d\":\"%s\"}" % (
+    qs = dict(BASE_QUERY)
+    qs['LAYER'] = 'france_parts'
+    qs['STRINGS'] = "{\"a\":\"%s\", \"b\":\"%s\", \"c\":\"%s\", \"d\":\"%s\"}" % (
         quote('[% 1 %]', safe=''), quote('[% 1 + 1 %]', safe=''), quote('[% prop0 %]', safe=''),
         quote('[% $x %]', safe=''))
-    qs += "&FEATURES=["
-    qs += "{\"type\":\"Feature\", \"geometry\": {\"type\": \"Point\", \"coordinates\": [102.0, 0.5]}, \"properties\": {\"prop0\": \"value0\"}}"
-    qs += ", "
-    qs += "{\"type\":\"Feature\", \"geometry\": {\"type\": \"Point\", \"coordinates\": [105.0, 0.5]}, \"properties\": {\"prop0\": \"value1\"}}"
-    rv = client.get(qs, PROJECT_FILE)
-    assert rv.status_code == 400
-    assert rv.headers.get('Content-Type', '').find('application/json') == 0
+    qs['FEATURES'] = (
+        "["
+        + "{\"type\":\"Feature\", \"geometry\": {\"type\": \"Point\", \"coordinates\": [102.0, 0.5]}, \"properties\": {\"prop0\": \"value0\"}}"
+        + ", "
+        + "{\"type\":\"Feature\", \"geometry\": {\"type\": \"Point\", \"coordinates\": [105.0, 0.5]}, \"properties\": {\"prop0\": \"value1\"}}"
+    )
+    rv = client.get(_build_query_string(qs), PROJECT_FILE)
+    _check_request(rv, http_code=400)
 
 
 def test_request_without_features(client):
     """  Test Expression replaceExpressionText request without Feature or Features parameter
     """
     # Make a request
-    qs = f"?SERVICE=EXPRESSION&REQUEST=replaceExpressionText&MAP={PROJECT_FILE}&LAYER=france_parts&STRING=%s" % (
-        quote('[% 1 + 1 %]', safe=''))
-    rv = client.get(qs, PROJECT_FILE)
-    assert rv.status_code == 200
-    assert rv.headers.get('Content-Type', '').find('application/json') == 0
-
-    b = json.loads(rv.content.decode('utf-8'))
+    qs = dict(BASE_QUERY)
+    qs['LAYER'] = 'france_parts'
+    qs['STRING'] = quote('[% 1 + 1 %]', safe='')
+    rv = client.get(_build_query_string(qs), PROJECT_FILE)
+    b = _check_request(rv)
 
     assert 'status' in b
     assert b['status'] == 'success'
@@ -95,11 +94,12 @@ def test_request_without_features(client):
     assert '0' in b['results'][0]
     assert b['results'][0]['0'] == '2'
 
-    qs = f"?SERVICE=EXPRESSION&REQUEST=replaceExpressionText&MAP={PROJECT_FILE}&LAYER=france_parts&STRINGS=[\"%s\", \"%s\"]" % (
+    qs = dict(BASE_QUERY)
+    qs['LAYER'] = 'france_parts'
+    qs['STRINGS'] = "[\"%s\", \"%s\"]" % (
         quote('[% 1 %]', safe=''), quote('[% 1 + 1 %]', safe=''))
-    rv = client.get(qs, PROJECT_FILE)
-    assert rv.status_code == 200
-    assert rv.headers.get('Content-Type', '').find('application/json') == 0
+    rv = client.get(_build_query_string(qs), PROJECT_FILE)
+    b = _check_request(rv)
 
     b = json.loads(rv.content.decode('utf-8'))
 
@@ -113,11 +113,12 @@ def test_request_without_features(client):
     assert '1' in b['results'][0]
     assert b['results'][0]['1'] == '2'
 
-    qs = "?SERVICE=EXPRESSION&REQUEST=replaceExpressionText&MAP=%s&LAYER=france_parts&STRINGS={\"a\":\"%s\", \"b\":\"%s\"}" % (
-        PROJECT_FILE, quote('[% 1 %]', safe=''), quote('[% 1 + 1 %]', safe=''))
-    rv = client.get(qs, PROJECT_FILE)
-    assert rv.status_code == 200
-    assert rv.headers.get('Content-Type', '').find('application/json') == 0
+    qs = dict(BASE_QUERY)
+    qs['LAYER'] = 'france_parts'
+    qs['STRINGS'] = "{\"a\":\"%s\", \"b\":\"%s\"}" % (
+        quote('[% 1 %]', safe=''), quote('[% 1 + 1 %]', safe=''))
+    rv = client.get(_build_query_string(qs), PROJECT_FILE)
+    b = _check_request(rv)
 
     b = json.loads(rv.content.decode('utf-8'))
 
@@ -136,16 +137,14 @@ def test_request_with_features(client):
     """  Test Expression replaceExpressionText request with Feature or Features parameter
     """
     # Make a request
-    qs = f"?SERVICE=EXPRESSION&REQUEST=replaceExpressionText&MAP={PROJECT_FILE}&LAYER=france_parts"
-    qs += "&STRINGS={\"a\":\"%s\", \"b\":\"%s\", \"c\":\"%s\", \"d\":\"%s\"}" % (
+    qs = dict(BASE_QUERY)
+    qs['LAYER'] = 'france_parts'
+    qs['STRINGS'] = "{\"a\":\"%s\", \"b\":\"%s\", \"c\":\"%s\", \"d\":\"%s\"}" % (
         quote('[% 1 %]', safe=''), quote('[% 1 + 1 %]', safe=''), quote('[% prop0 %]', safe=''),
         quote('[% $x %]', safe=''))
-    qs += "&FEATURE={\"type\":\"Feature\", \"geometry\": {\"type\": \"Point\", \"coordinates\": [102.0, 0.5]}, \"properties\": {\"prop0\": \"value0\"}}"
-    rv = client.get(qs, PROJECT_FILE)
-    assert rv.status_code == 200
-    assert rv.headers.get('Content-Type', '').find('application/json') == 0
-
-    b = json.loads(rv.content.decode('utf-8'))
+    qs['FEATURE'] = "{\"type\":\"Feature\", \"geometry\": {\"type\": \"Point\", \"coordinates\": [102.0, 0.5]}, \"properties\": {\"prop0\": \"value0\"}}"
+    rv = client.get(_build_query_string(qs), PROJECT_FILE)
+    b = _check_request(rv)
 
     assert 'status' in b
     assert b['status'] == 'success'
@@ -161,20 +160,20 @@ def test_request_with_features(client):
     assert b['results'][0]['d'] == '102'
 
     # Make a request
-    qs = f"?SERVICE=EXPRESSION&REQUEST=replaceExpressionText&MAP={PROJECT_FILE}&LAYER=france_parts"
-    qs += "&STRINGS={\"a\":\"%s\", \"b\":\"%s\", \"c\":\"%s\", \"d\":\"%s\"}" % (
+    qs = dict(BASE_QUERY)
+    qs['LAYER'] = 'france_parts'
+    qs['STRINGS'] = "{\"a\":\"%s\", \"b\":\"%s\", \"c\":\"%s\", \"d\":\"%s\"}" % (
         quote('[% 1 %]', safe=''), quote('[% 1 + 1 %]', safe=''), quote('[% prop0 %]', safe=''),
         quote('[% $x %]', safe=''))
-    qs += "&FEATURES=["
-    qs += "{\"type\":\"Feature\", \"geometry\": {\"type\": \"Point\", \"coordinates\": [102.0, 0.5]}, \"properties\": {\"prop0\": \"value0\"}}"
-    qs += ", "
-    qs += "{\"type\":\"Feature\", \"geometry\": {\"type\": \"Point\", \"coordinates\": [105.0, 0.5]}, \"properties\": {\"prop0\": \"value1\"}}"
-    qs += "]"
-    rv = client.get(qs, PROJECT_FILE)
-    assert rv.status_code == 200
-    assert rv.headers.get('Content-Type', '').find('application/json') == 0
-
-    b = json.loads(rv.content.decode('utf-8'))
+    qs['FEATURES'] = (
+        "["
+        + "{\"type\":\"Feature\", \"geometry\": {\"type\": \"Point\", \"coordinates\": [102.0, 0.5]}, \"properties\": {\"prop0\": \"value0\"}}"
+        + ", "
+        + "{\"type\":\"Feature\", \"geometry\": {\"type\": \"Point\", \"coordinates\": [105.0, 0.5]}, \"properties\": {\"prop0\": \"value1\"}}"
+        + "]"
+    )
+    rv = client.get(_build_query_string(qs), PROJECT_FILE)
+    b = _check_request(rv)
 
     assert 'status' in b
     assert b['status'] == 'success'
@@ -199,16 +198,14 @@ def test_request_with_features_all(client):
     """  Test Expression replaceExpressionText request with Feature or Features parameter
     """
     # Make a request
-    qs = f"?SERVICE=EXPRESSION&REQUEST=replaceExpressionText&MAP={PROJECT_FILE}&LAYER=france_parts"
-    qs += "&STRINGS={\"a\":\"%s\", \"b\":\"%s\", \"c\":\"%s\", \"d\":\"%s\"}" % (
+    qs = dict(BASE_QUERY)
+    qs['LAYER'] = 'france_parts'
+    qs['STRINGS'] = "{\"a\":\"%s\", \"b\":\"%s\", \"c\":\"%s\", \"d\":\"%s\"}" % (
         quote('[% 1 %]', safe=''), quote('[% 1 + 1 %]', safe=''), quote('[% NAME_1 %]', safe=''),
         quote('[% round($area) %]', safe=''))
-    qs += "&FEATURES=ALL"
-    rv = client.get(qs, PROJECT_FILE)
-    assert rv.status_code == 200
-    assert rv.headers.get('Content-Type', '').find('application/json') == 0
-
-    b = json.loads(rv.content.decode('utf-8'))
+    qs['FEATURES'] = "ALL"
+    rv = client.get(_build_query_string(qs), PROJECT_FILE)
+    b = _check_request(rv)
 
     assert 'status' in b
     assert b['status'] == 'success'
@@ -228,17 +225,15 @@ def test_request_with_features_all(client):
 def test_request_with_form_scope(client):
     """  Test Expression replaceExpressionText request without Feature or Features and Form_Scope parameters
     """
-    qs = f"?SERVICE=EXPRESSION&REQUEST=replaceExpressionText&MAP={PROJECT_FILE}&LAYER=france_parts"
-    qs += "&STRINGS={\"a\":\"%s\", \"b\":\"%s\", \"c\":\"%s\", \"d\":\"%s\"}" % (
+    qs = dict(BASE_QUERY)
+    qs['LAYER'] = 'france_parts'
+    qs['STRINGS'] = "{\"a\":\"%s\", \"b\":\"%s\", \"c\":\"%s\", \"d\":\"%s\"}" % (
         quote('[% 1 %]', safe=''), quote('[% 1 + 1 %]', safe=''), quote("[% current_value('prop0') %]", safe=''),
         quote('[% $x %]', safe=''))
-    qs += "&FEATURE={\"type\":\"Feature\", \"geometry\": {\"type\": \"Point\", \"coordinates\": [102.0, 0.5]}, \"properties\": {\"prop0\": \"value0\"}}"
-    qs += "&FORM_SCOPE=true"
-    rv = client.get(qs, PROJECT_FILE)
-    assert rv.status_code == 200
-    assert rv.headers.get('Content-Type', '').find('application/json') == 0
-
-    b = json.loads(rv.content.decode('utf-8'))
+    qs['FEATURE'] = "{\"type\":\"Feature\", \"geometry\": {\"type\": \"Point\", \"coordinates\": [102.0, 0.5]}, \"properties\": {\"prop0\": \"value0\"}}"
+    qs['FORM_SCOPE'] = 'true'
+    rv = client.get(_build_query_string(qs), PROJECT_FILE)
+    b = _check_request(rv)
 
     assert 'status' in b
     assert b['status'] == 'success'
@@ -255,17 +250,14 @@ def test_request_with_form_scope(client):
 
     # Make a request without form scope but with current_value function
     # One template has multiple expressions
-    qs = f"?SERVICE=EXPRESSION&REQUEST=replaceExpressionText&MAP={PROJECT_FILE}&LAYER=france_parts"
-    qs += "&STRINGS={\"a\":\"%s\", \"b\":\"%s\", \"c\":\"%s\", \"d\":\"%s\"}" % (
-        quote('[% 1 %]', safe=''), quote('[% 1 + 1 %] [% 2 + 2 %]', safe=''), quote("[% current_value('prop0') %]", safe=''),
+    qs = dict(BASE_QUERY)
+    qs['LAYER'] = 'france_parts'
+    qs['STRINGS'] = "{\"a\":\"%s\", \"b\":\"%s\", \"c\":\"%s\", \"d\":\"%s\"}" % (
+        quote('[% 1 %]', safe=''), quote('[% 1 + 1 %]', safe=''), quote("[% current_value('prop0') %]", safe=''),
         quote('[% $x %]', safe=''))
-    qs += "&FEATURE={\"type\":\"Feature\", \"geometry\": {\"type\": \"Point\", \"coordinates\": [102.0, 0.5]}, \"properties\": {\"prop0\": \"value0\"}}"
-    rv = client.get(qs, PROJECT_FILE)
-    assert rv.status_code == 200
-
-    assert rv.headers.get('Content-Type', '').find('application/json') == 0
-
-    b = json.loads(rv.content.decode('utf-8'))
+    qs['FEATURE'] = "{\"type\":\"Feature\", \"geometry\": {\"type\": \"Point\", \"coordinates\": [102.0, 0.5]}, \"properties\": {\"prop0\": \"value0\"}}"
+    rv = client.get(_build_query_string(qs), PROJECT_FILE)
+    b = _check_request(rv)
 
     assert 'status' in b
     assert b['status'] == 'success'
@@ -275,7 +267,7 @@ def test_request_with_form_scope(client):
     assert 'a' in b['results'][0]
     assert b['results'][0]['a'] == '1'
     assert 'b' in b['results'][0]
-    assert b['results'][0]['b'] == '2 4'
+    assert b['results'][0]['b'] == '2'
     assert b['results'][0]['c'] == ''
     assert 'd' in b['results'][0]
     assert b['results'][0]['d'] == '102'
@@ -285,17 +277,15 @@ def test_request_with_features_geojson(client):
     """  Test Expression replaceExpressionText request with Feature or Features parameter
     """
     # Make a request
-    qs = f"?SERVICE=EXPRESSION&REQUEST=replaceExpressionText&MAP={PROJECT_FILE}&LAYER=france_parts"
-    qs += "&STRINGS={\"a\":\"%s\", \"b\":\"%s\", \"c\":\"%s\", \"d\":\"%s\"}" % (
-        quote('[% 1 %]', safe=''), quote('[% 1 + 1 %]', safe=''), quote('[% prop0 %]', safe=''),
+    qs = dict(BASE_QUERY)
+    qs['LAYER'] = 'france_parts'
+    qs['STRINGS'] = "{\"a\":\"%s\", \"b\":\"%s\", \"c\":\"%s\", \"d\":\"%s\"}" % (
+        quote('[% 1 %]', safe=''), quote('[% 1 + 1 %]', safe=''), quote("[% prop0 %]", safe=''),
         quote('[% $x %]', safe=''))
-    qs += "&FEATURE={\"type\":\"Feature\", \"geometry\": {\"type\": \"Point\", \"coordinates\": [102.0, 0.5]}, \"properties\": {\"prop0\": \"value0\"}}"
-    qs += "&FORMAT=GeoJSON"
-    rv = client.get(qs, PROJECT_FILE)
-    assert rv.status_code == 200
-    assert rv.headers.get('Content-Type', '').find('application/vnd.geo+json') == 0
-
-    b = json.loads(rv.content.decode('utf-8'))
+    qs['FEATURE'] = "{\"type\":\"Feature\", \"geometry\": {\"type\": \"Point\", \"coordinates\": [102.0, 0.5]}, \"properties\": {\"prop0\": \"value0\"}}"
+    qs['FORMAT'] = 'GeoJSON'
+    rv = client.get(_build_query_string(qs), PROJECT_FILE)
+    b = _check_request(rv, content_type='application/vnd.geo+json')
 
     assert 'type' in b
     assert b['type'] == 'FeatureCollection'
@@ -315,21 +305,21 @@ def test_request_with_features_geojson(client):
     assert b['features'][0]['properties']['d'] == '102'
 
     # Make a request
-    qs = f"?SERVICE=EXPRESSION&REQUEST=replaceExpressionText&MAP={PROJECT_FILE}&LAYER=france_parts"
-    qs += "&STRINGS={\"a\":\"%s\", \"b\":\"%s\", \"c\":\"%s\", \"d\":\"%s\"}" % (
-        quote('[% 1 %]', safe=''), quote('[% 1 + 1 %]', safe=''), quote('[% prop0 %]', safe=''),
+    qs = dict(BASE_QUERY)
+    qs['LAYER'] = 'france_parts'
+    qs['STRINGS'] = "{\"a\":\"%s\", \"b\":\"%s\", \"c\":\"%s\", \"d\":\"%s\"}" % (
+        quote('[% 1 %]', safe=''), quote('[% 1 + 1 %]', safe=''), quote("[% prop0 %]", safe=''),
         quote('[% $x %]', safe=''))
-    qs += "&FEATURES=["
-    qs += "{\"type\":\"Feature\", \"geometry\": {\"type\": \"Point\", \"coordinates\": [102.0, 0.5]}, \"properties\": {\"prop0\": \"value0\"}}"
-    qs += ", "
-    qs += "{\"type\":\"Feature\", \"geometry\": {\"type\": \"Point\", \"coordinates\": [105.0, 0.5]}, \"properties\": {\"prop0\": \"value1\"}}"
-    qs += "]"
-    qs += "&FORMAT=GeoJSON"
-    rv = client.get(qs, PROJECT_FILE)
-    assert rv.status_code == 200
-    assert rv.headers.get('Content-Type', '').find('application/vnd.geo+json') == 0
-
-    b = json.loads(rv.content.decode('utf-8'))
+    qs['FEATURES'] = (
+        "["
+        + "{\"type\":\"Feature\", \"geometry\": {\"type\": \"Point\", \"coordinates\": [102.0, 0.5]}, \"properties\": {\"prop0\": \"value0\"}}"
+        + ", "
+        + "{\"type\":\"Feature\", \"geometry\": {\"type\": \"Point\", \"coordinates\": [105.0, 0.5]}, \"properties\": {\"prop0\": \"value1\"}}"
+        + "]"
+    )
+    qs['FORMAT'] = 'GeoJSON'
+    rv = client.get(_build_query_string(qs), PROJECT_FILE)
+    b = _check_request(rv, content_type='application/vnd.geo+json')
 
     assert 'type' in b
     assert b['type'] == 'FeatureCollection'
@@ -360,17 +350,15 @@ def test_request_with_features_all_geojson(client):
     """  Test Expression replaceExpressionText request with Feature or Features parameter
     """
     # Make a request
-    qs = f"?SERVICE=EXPRESSION&REQUEST=replaceExpressionText&MAP={PROJECT_FILE}&LAYER=france_parts"
-    qs += "&STRINGS={\"a\":\"%s\", \"b\":\"%s\", \"c\":\"%s\", \"d\":\"%s\"}" % (
+    qs = dict(BASE_QUERY)
+    qs['LAYER'] = 'france_parts'
+    qs['STRINGS'] = "{\"a\":\"%s\", \"b\":\"%s\", \"c\":\"%s\", \"d\":\"%s\"}" % (
         quote('[% 1 %]', safe=''), quote('[% 1 + 1 %]', safe=''), quote('[% NAME_1 %]', safe=''),
         quote('[% round($area) %]', safe=''))
-    qs += "&FEATURES=ALL"
-    qs += "&FORMAT=GeoJSON"
-    rv = client.get(qs, PROJECT_FILE)
-    assert rv.status_code == 200
-    assert rv.headers.get('Content-Type', '').find('application/vnd.geo+json') == 0
-
-    b = json.loads(rv.content.decode('utf-8'))
+    qs['FEATURES'] = "ALL"
+    qs['FORMAT'] = "GeoJSON"
+    rv = client.get(_build_query_string(qs), PROJECT_FILE)
+    b = _check_request(rv, content_type='application/vnd.geo+json')
 
     assert 'type' in b
     assert b['type'] == 'FeatureCollection'


### PR DESCRIPTION
For `replaceExpressionText` request of `Expression` service, it is possible to perform `replaceExpressionText` on all features of the layer and to get result as GeoJSON.

To do so, you have to specify `FEATURES=ALL` and `Format=GeoJSON` in the request URL.