### PR TITLE
Remove third party service from the Lizmap API

### DIFF
--- a/lizmap_server/server_info_handler.py
+++ b/lizmap_server/server_info_handler.py
@@ -174,7 +174,7 @@ class ServerInfoHandler(QgsServerOgcApiHandler):
         human_version, human_name = Qgis.QGIS_VERSION.split('-', 1)
 
         services_available = []
-        expected_services = ('WMS', 'WFS', 'WCS', 'WMTS', 'ATLAS', 'CADASTRE', 'EXPRESSION', 'LIZMAP')
+        expected_services = ('WMS', 'WFS', 'WCS', 'WMTS', 'EXPRESSION', 'LIZMAP')
         for service in expected_services:
             if context.serverInterface().serviceRegistry().getService(service):
                 services_available.append(service)


### PR DESCRIPTION
It looks like not the best idea to check for a "predefined list" of SERVICE to look for

For Cadastre and AtlasPrint, it looks more logical to check if the plugin is returned in the list of plugins installed, instead of hardcoding a list of service in the plugin itself.

Fixing a logging error about unknonwn service as well : https://github.com/3liz/lizmap-web-client/issues/4462


If I'm not wrong, it's not used in LWC source code anyway