### PR TITLE
Fix invalid test in to_bool

### DIFF
--- a/lizmap_server/get_legend_graphic.py
+++ b/lizmap_server/get_legend_graphic.py
@@ -83,7 +83,7 @@ class GetLegendGraphicFilter(QgsServerFilter):
         if not style:
             style = params.get('STYLE', '')
 
-        show_feature_count = to_bool(params.get('SHOWFEATURECOUNT'), default_value=False)
+        show_feature_count = to_bool(params.get('SHOWFEATURECOUNT'))
 
         current_style = ''
         layer = find_layer(layer_name, project)

--- a/lizmap_server/plausible.py
+++ b/lizmap_server/plausible.py
@@ -39,11 +39,11 @@ class Plausible:
 
     def request_stat_event(self) -> bool:
         """ Request to send an event to the API. """
-        if to_bool(os.getenv(ENV_SKIP_STATS), default_value=False):
+        if to_bool(os.getenv(ENV_SKIP_STATS)):
             # Disabled by environment variable
             return False
 
-        if to_bool(os.getenv("CI"), default_value=False):
+        if to_bool(os.getenv("CI")):
             # If running on CI, do not send stats
             return False
 

--- a/lizmap_server/tools.py
+++ b/lizmap_server/tools.py
@@ -15,16 +15,13 @@ Tools for Lizmap.
 """
 
 
-def to_bool(val: Union[str, int, float, bool], default_value: bool = True) -> bool:
+def to_bool(val: Union[str, int, float, bool, None]) -> bool:
     """ Convert lizmap config value to boolean """
     if isinstance(val, str):
         # For string, compare lower value to True string
         return val.lower() in ('yes', 'true', 't', '1')
-    elif not val:
-        # For value like False, 0, 0.0, None, empty list or dict returns False
-        return False
     else:
-        return default_value
+        return bool(val)
 
 
 def version() -> str:
@@ -49,7 +46,7 @@ def version() -> str:
 
 def check_environment_variable() -> bool:
     """ Check the server configuration. """
-    if not to_bool(os.environ.get('QGIS_SERVER_LIZMAP_REVEAL_SETTINGS', ''), default_value=False):
+    if not to_bool(os.environ.get('QGIS_SERVER_LIZMAP_REVEAL_SETTINGS', '')):
         QgsMessageLog.logMessage(
             'The Lizmap API is currently not enabled. Please read the documentation how to enable the Lizmap API '
             'on QGIS server side '


### PR DESCRIPTION
The  value  `default_value` is returned  only   if the tested vaiue is evaluated to `False`. 
By default `default_value` is  `True` then if the  parameter is not given explicitely it is useless because we return the same value as the tested one.

If  `default_value` si  `False`: 
* If the tested value is a string then `default_value` has no effect
* If the tested value is not a string  and evaluated to `False` we return `False`
* If the tested value is not a string and evaluated to  `True` we return `False` 

=> This means that  this test only check if the tested value is a string and not the value we want to test !

In the source code, `default_value` is explicitely set to `False` only when testing a string (from `os.getenv`) and so `default_value` has - hopefully - no effect.
