### PR TITLE
Provide the Git repository and documentation URL for each context

### DIFF
--- a/lizmap_server/context/common.py
+++ b/lizmap_server/context/common.py
@@ -62,6 +62,20 @@ class ContextABC(ABC):
 
     @property
     @abstractmethod
+    def git_repository_url(self) -> str:
+        """ Return Git repository URL
+        """
+        ...
+
+    @property
+    @abstractmethod
+    def documentation_url(self) -> str:
+        """ Return documentation URL
+        """
+        ...
+
+    @property
+    @abstractmethod
     def search_paths(self) -> List[str]:
         """ Return search paths for projects
         """

--- a/lizmap_server/context/native.py
+++ b/lizmap_server/context/native.py
@@ -32,6 +32,14 @@ class Context(ContextABC):
         return SERVER_CONTEXT_NAME
 
     @property
+    def git_repository_url(self) -> str:
+        return "https://github.com/qgis/QGIS"
+
+    @property
+    def documentation_url(self) -> str:
+        return "https://docs.qgis.org/latest/en/docs/server_manual/"
+
+    @property
     def search_paths(self) -> List[str]:
         """ Return search paths for projects
         """

--- a/lizmap_server/context/py_qgis_server.py
+++ b/lizmap_server/context/py_qgis_server.py
@@ -31,6 +31,14 @@ class Context(ContextABC):
         return SERVER_CONTEXT_NAME
 
     @property
+    def git_repository_url(self) -> str:
+        return "https://github.com/3liz/py-qgis-server"
+
+    @property
+    def documentation_url(self) -> str:
+        return "https://docs.3liz.org/py-qgis-server/"
+
+    @property
     def search_paths(self) -> List[str]:
         """ Return search paths for projects
         """

--- a/lizmap_server/context/py_qgis_server2.py
+++ b/lizmap_server/context/py_qgis_server2.py
@@ -36,6 +36,14 @@ class Context(ContextABC):
         return SERVER_CONTEXT_NAME
 
     @property
+    def git_repository_url(self) -> str:
+        return "https://github.com/3liz/py-qgis-server2"
+
+    @property
+    def documentation_url(self) -> str:
+        return ""
+
+    @property
     def search_paths(self) -> List[str]:
         """ Return search paths for projects
         """

--- a/lizmap_server/server_info_handler.py
+++ b/lizmap_server/server_info_handler.py
@@ -156,6 +156,8 @@ class ServerInfoHandler(QgsServerOgcApiHandler):
                 build_id=server_metadata.build_id,
                 commit_id=server_metadata.commit_id,
                 stable=server_metadata.is_stable,
+                git_repository_url=self._context.git_repository_url,
+                documentation_url=self._context.documentation_url,
             )
         else:
             py_qgis_server = dict(found=False, version="not used")

--- a/test/test_server_info.py
+++ b/test/test_server_info.py
@@ -56,6 +56,7 @@ def test_lizmap_server_info(client):
         assert json_content['qgis_server']['plugins'][plugin]['version'] == 'Not found'
 
     assert len(json_content['qgis_server']['fonts']) >= 1
+    assert len(json_content['qgis_server'].get('py_qgis_server').keys()) >= 2
 
 
 def test_tos_checks(client):


### PR DESCRIPTION
In LWC, we need to know the URL for Py-QGIS-Server or Py-QGIS-Server 2.

For now, the URL is hardcoded in the LWC source code.
