### PR TITLE
Change QJazz metadata package

### DIFF
--- a/lizmap_server/context/qjazz.py
+++ b/lizmap_server/context/qjazz.py
@@ -109,10 +109,8 @@ class Context(ContextABC):
         from qjazz_contrib.core import manifest
 
         commit = manifest.get_manifest().commit_id
-        if commit:
-            commit = commit[:12]
 
-        version = metadata.version('qjazz_cache')
+        version = metadata.version('qjazz_contrib')
         return ServerMetadata(
             name=SERVER_CONTEXT_NAME,
             commit_id=commit,


### PR DESCRIPTION
Replace `qjazz_cache` metadata lookup by `qjazz_config` metadata.

`qjazz_cache` is now  a  module included in the `qjazz-contrib` distribution package and thus has no metadata associated to it;
this will prevent lizmap server to crash when used with QJazz.

 
