### PR TITLE
feat: Allow some virtuals to be discarded if not considered safe

### DIFF
--- a/lizmap_server/definitions/__init__.py
+++ b/lizmap_server/definitions/__init__.py
@@ -1,0 +1,3 @@
+__copyright__ = 'Copyright 2025, 3Liz'
+__license__ = 'GPL version 3'
+__email__ = 'info@3liz.org'

--- a/lizmap_server/definitions/safe_expressions.py
+++ b/lizmap_server/definitions/safe_expressions.py
@@ -1,0 +1,15 @@
+__copyright__ = 'Copyright 2025, 3Liz'
+__license__ = 'GPL version 3'
+__email__ = 'info@3liz.org'
+
+# Some expressions which can be evaluated on the server
+ALLOWED_SAFE_EXPRESSIONS = {
+    'area',
+    '$area',
+    'display_expression',
+    'format_date',
+    'now',
+    'represent_value',
+    'round',
+}
+NOT_ALLOWED_EXPRESSION = "'not allowed'"


### PR DESCRIPTION
Related to `lizmap-features-table`, to be able to set any arbitrary column, but as to be safe from Javascript expression injection, we must set a allowed list of expressions.

The code in LWC will be removed and additional columns will be sent using this new parameter : 
https://github.com/3liz/lizmap-web-client/blob/master/lizmap/modules/lizmap/controllers/features.classic.php#L222

The use case is `represent_value` in the training https://formation.lizmap.com/paysdefayence/