### PR TITLE
[linter] fix supported python version for QJazz context

### DIFF
--- a/lizmap_server/context/qjazz.py
+++ b/lizmap_server/context/qjazz.py
@@ -55,21 +55,19 @@ class Context(ContextABC):
 
         rv = None
 
-        # Do not use match since we must keep compatibility with Python >= 3.7
-        # TODO replace if/elif by match when QGIS 3.34 will be the minimum version
-        # match co_status:
-        if co_status in (Co.UNCHANGED, Co.NEEDUPDATE):
-            rv = md.project
-        elif co_status == Co.NEW:
-            raise ProjectCacheError(403, f"Requested project not in cache: {uri}")
-        elif co_status == Co.NOTFOUND:
-            # Unexistent project
-            raise ProjectCacheError(404, f"Requested project not found: {uri}")
-        elif co_status == Co.REMOVED:
-            # Do not return a removed project
-            # Since layer's data may not exist
-            # anymore
-            raise ProjectCacheError(410, f"Requested removed project: {uri}")
+        match co_status:
+            case Co.UNCHANGED | Co.NEEDUPDATE:
+                rv = md.project
+            case Co.NEW:
+                raise ProjectCacheError(403, f"Requested project not in cache: {uri}")
+            case Co.NOTFOUND:
+                # Unexistent project
+                raise ProjectCacheError(404, f"Requested project not found: {uri}")
+            case Co.REMOVED:
+                # Do not return a removed project
+                # Since layer's data may not exist
+                # anymore
+                raise ProjectCacheError(410, f"Requested removed project: {uri}")
 
         return rv
 

--- a/lizmap_server/server_info_handler.py
+++ b/lizmap_server/server_info_handler.py
@@ -7,7 +7,7 @@ import sys
 import traceback
 import warnings
 
-from typing import Union
+from typing import Optional
 
 from qgis.core import Qgis
 from qgis.PyQt import Qt
@@ -191,7 +191,7 @@ class ServerInfoHandler(QgsServerOgcApiHandler):
         }
         self.write(data, context)
 
-    def support_custom_headers(self) -> Union[None, bool]:
+    def support_custom_headers(self) -> Optional[bool]:
         """ Check if this QGIS Server supports custom headers.
 
          Returns None if the check is not requested with the GET parameter CHECK_CUSTOM_HEADERS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,9 @@ ignore = [
     "RUF100",
 ]
 
+[tool.ruff.per-file-target-version]
+"lizmap_server/context/qjazz.py" = "py312"
+
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = [
     "T201",


### PR DESCRIPTION
 Restore python 3.12+ match syntax for QJazz context and set linter `tool.ruff.per-file-target-version` settings accordingly
(revert #115)

QJazz context module is loaded only when used with QJazz and QJazz require Python 3.12+.