### PR TITLE
Tests: Enhancing Expression Evaluate Request

### DIFF
--- a/lizmap_server/expression_service.py
+++ b/lizmap_server/expression_service.py
@@ -325,6 +325,7 @@ class ExpressionService(QgsService):
                     error[k] = exp.expression()
             body['results'].append(result)
             body['errors'].append(error)
+            body['features'] += 1
 
         write_json_response(body, response)
         return


### PR DESCRIPTION
Enhancing tests for Expression Evaluate Request, started because `"has_photo" = true` or `"has_photo" IS true` when the field `has_photo` has a simple character as value like `t`, `f` or `c`