### PR TITLE
Fix QJazz module imports

### DIFF
--- a/lizmap_server/context/common.py
+++ b/lizmap_server/context/common.py
@@ -87,12 +87,6 @@ class ContextABC(ABC):
         ...
 
     @abstractmethod
-    def catalog(self, search_path: Optional[str] = None) -> List[CatalogItem]:
-        """ Return the projects catalog
-        """
-        ...
-
-    @abstractmethod
     def installed_plugins(
         self,
         keys: Sequence[str],

--- a/lizmap_server/context/native.py
+++ b/lizmap_server/context/native.py
@@ -1,7 +1,5 @@
 """ Native QGIS context
 """
-from itertools import chain
-from pathlib import Path
 from typing import (
     Dict,
     Iterator,
@@ -15,11 +13,9 @@ from qgis.core import QgsProject
 from qgis.utils import pluginMetadata, server_active_plugins
 
 from .common import (
-    CatalogItem,
     ContextABC,
     ProjectCacheError,
     ServerMetadata,
-    to_iso8601,
 )
 
 SERVER_CONTEXT_NAME = 'FCGI'
@@ -50,31 +46,6 @@ class Context(ContextABC):
         """
         # TODO Fix me
         raise ProjectCacheError(403, f"Project not found in cache: {uri}")
-
-    def catalog(self, search_path: Optional[str] = None) -> List[CatalogItem]:
-        """ Return the catalog of projects
-
-            location is a relative path to the root uri
-        """
-        location = Path(search_path or '.')
-
-        if not location.is_dir():
-            return []
-
-        def _items():
-            glob_pattern = '**/*.%s'
-            files = chain(*(location.glob(glob_pattern % sfx) for sfx in ('qgs', 'qgz')))
-            for p in files:
-                st = p.stat()
-                yield CatalogItem(
-                    uri=str(p),
-                    name=p.stem,
-                    storage='file',
-                    last_modified=to_iso8601(st.st_mtime),
-                    public_uri=str(p),
-                )
-
-        return list(_items())
 
     def installed_plugins(
         self,

--- a/lizmap_server/context/qjazz.py
+++ b/lizmap_server/context/qjazz.py
@@ -1,19 +1,17 @@
 from functools import cached_property
 from typing import Dict, Iterator, List, Optional, Sequence, Tuple
 
-from qjazz_contrib.core.qgis import QgisPluginService
-from qjazz_contrib.core import logger
+from qjazz_core.qgis import QgisPluginService
+from qjazz_core import logger
 from qjazz_cache.prelude import CacheEntry, CacheManager, ProjectMetadata
 from qjazz_cache.prelude import CheckoutStatus as Co
 
 from qgis.core import QgsProject
 
 from .common import (
-    CatalogItem,
     ContextABC,
     ProjectCacheError,
     ServerMetadata,
-    to_iso8601,
 )
 
 
@@ -70,19 +68,6 @@ class Context(ContextABC):
                 raise ProjectCacheError(410, f"Requested removed project: {uri}")
 
         return rv
-
-    def catalog(self, search_path: Optional[str] = None) -> List[CatalogItem]:
-        """ Return the catalog of projects
-        """
-        return [
-            CatalogItem(
-                uri=md.uri,
-                name=md.name,
-                storage=md.storage,
-                last_modified=to_iso8601(md.last_modified),
-                public_uri=public_path,
-            ) for md, public_path in self._cm.collect_projects(search_path)
-        ]
 
     def installed_plugins(
         self,


### PR DESCRIPTION
Fix invalid  module imports in QJazz context

Remove unused `catalog` method which may  is inneficient and may cause problems with large directories.
