### PR TITLE
Tests: Put bandit to severity check medium fro plugins.qgis.org

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
             ruff check --output-format=concise lizmap_server
 
       - name: Run security check
-        run: bandit -r lizmap_server --severity-level=high
+        run: bandit -r lizmap_server -ll
 
   tests:
     needs: [linter]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 SHELL:=bash
 
 PYTHON_MODULE=lizmap_server
+SCAN_OPTS=-ll
 
 TESTS=tests
 
@@ -54,7 +55,7 @@ openapi:
 
 LINT_TARGETS=$(PYTHON_MODULE) $(TESTS) $(EXTRA_LINT_TARGETS)
 
-lint:: 
+lint::
 	@ $(UV) ruff check --output-format=concise $(LINT_TARGETS)
 
 lint:: typecheck
@@ -66,7 +67,7 @@ lint-fix:
 	@ $(UV) ruff check  --fix $(LINT_TARGETS)
 
 format:
-	@ $(UV) ruff format $(LINT_TARGETS) 
+	@ $(UV) ruff format $(LINT_TARGETS)
 
 typecheck:
 	@ $(UV) ty check

--- a/lizmap_server/filter_by_polygon.py
+++ b/lizmap_server/filter_by_polygon.py
@@ -10,6 +10,7 @@ from typing import (
     cast,
 )
 
+from psycopg2 import connect, sql
 from qgis.core import (
     QgsCoordinateReferenceSystem,
     QgsCoordinateTransform,
@@ -323,23 +324,25 @@ array_intersect(
 
         Only for QGIS >= 3.10
         """
-        uri = QgsDataSourceUri(self.polygon.source())
 
         try:
-            sql = r"""
+            datasource = QgsDataSourceUri(self.polygon.source())
+
+            # psycopg2 composed request
+            query = sql.SQL("""
 WITH current_groups AS (
     SELECT
         ARRAY_REMOVE(
             STRING_TO_ARRAY(
                 regexp_replace(
-                    '{groups_or_user}', '[^a-zA-Z0-9_-]', ',', 'g'
+                    {groups_or_user}, '[^a-zA-Z0-9_-]', ',', 'g'
                 ),
                 ','
             ),
         '') AS user_group
 )
 SELECT
-        1 AS id, ST_AsBinary(ST_Union("{geom}")) AS geom
+        1 AS id, ST_AsBinary(ST_Union({geom})) AS geom
 FROM
         {table_name} AS p,
         current_groups AS c
@@ -348,7 +351,7 @@ c.user_group && (
     ARRAY_REMOVE(
         STRING_TO_ARRAY(
             regexp_replace(
-                "{polygon_field}", '[^a-zA-Z0-9_-]', ',', 'g'
+                {polygon_field}, '[^a-zA-Z0-9_-]', ',', 'g'
             ),
             ','
         ),
@@ -357,17 +360,20 @@ c.user_group && (
 
 
 
-""".format(
-                polygon_field=self.group_field,
-                groups_or_user=",".join(groups_or_user),
-                geom=uri.geometryColumn(),
-                table_name=FilterByPolygon._format_table_name(uri),
+""").format(
+                polygon_field=sql.Identifier(self.group_field),
+                groups_or_user=sql.Literal(",".join(groups_or_user)),
+                geom=sql.Identifier(datasource.geometryColumn()),
+                table_name=sql.Identifier(FilterByPolygon._format_table_name(datasource)),
             )
             logger.info(
                 f"Requesting the database about polygons for the current groups or user with : \n{sql}"
             )
 
-            results = self.sql_query(uri, sql)
+            # psycopg2 connection
+            conn = connect(datasource.connectionInfo())
+            # psycopg2 recomposed request as string
+            results = self.sql_query(datasource, query.as_string(conn))
             wkb = results[0][1]
 
             geom = QgsGeometry()
@@ -445,16 +451,22 @@ c.user_group && (
 
         :returns: The subset SQL string.
         """
-        uri = QgsDataSourceUri(self.layer.source())
+        datasource = QgsDataSourceUri(self.polygon.source())
 
-        sql = 'SELECT "{pk}" FROM {table_name} WHERE {st_intersect}'.format(
-            pk=self.primary_key,
-            table_name=FilterByPolygon._format_table_name(uri),
+        # psycopg2 composed request
+        query = sql.SQL("""
+            SELECT {pk} FROM {table_name} WHERE {st_intersect}
+        """).format(
+            pk=sql.Identifier(self.primary_key),
+            table_name=sql.Identifier(FilterByPolygon._format_table_name(datasource)),
             st_intersect=st_intersect,
         )
         logger.info(f"Requesting the database about IDs to filter with {sql[0:90]}...")
 
-        results = self.sql_query(uri, sql)
+        # psycopg2 connection
+        conn = connect(datasource.connectionInfo())
+        # psycopg2 recomposed request as string
+        results = self.sql_query(datasource, query.as_string(conn))
         unique_ids = [str(row[0]) for row in results]
 
         return self._format_sql_in(self.primary_key, unique_ids)

--- a/lizmap_server/get_feature_info.py
+++ b/lizmap_server/get_feature_info.py
@@ -1,5 +1,4 @@
 import json
-import xml.etree.ElementTree as ET
 
 from collections import namedtuple
 from pathlib import Path
@@ -18,6 +17,7 @@ from qgis.core import (
     QgsRelationManager,
 )
 from qgis.server import QgsServerFeatureId, QgsServerFilter, QgsServerProjectUtils
+from qgis.PyQt.QtXml import QDomDocument
 
 from .core import find_vector_layer
 from .tools import to_bool, _N
@@ -36,42 +36,68 @@ class GetFeatureInfoFilter(QgsServerFilter):
     @classmethod
     def parse_xml(cls, string: str) -> Generator[Tuple[str, str], None, None]:
         """Generator for layer and feature found in the XML GetFeatureInfo."""
-        root = ET.fromstring(string)
-        for layer in root:
-            for feature in layer:
-                if feature.attrib.get("id"):
-                    yield layer.attrib["name"], feature.attrib["id"]
+        dom_doc = QDomDocument("gfi")
+        dom_doc.setContent(string)
+        doc_elem = dom_doc.documentElement()
+
+        layer_elem = doc_elem.firstChildElement()
+        while not layer_elem.isNull():
+            if layer_elem.nodeName().upper() != "LAYER":
+                layer_elem = layer_elem.nextSiblingElement()
+                continue
+
+            feature_elem = layer_elem.firstChildElement()
+            while not feature_elem.isNull():
+                if feature_elem.hasAttribute("id"):
+                    yield layer_elem.attribute("name"), feature_elem.attribute('id')
+
+                feature_elem = feature_elem.nextSiblingElement()
+
+            layer_elem = layer_elem.nextSiblingElement()
 
     @classmethod
     def append_maptip(cls, string: str, layer_name: str, feature_id: Union[str, int], maptip: str) -> str:
         """Edit the XML GetFeatureInfo by adding a maptip for a given layer and feature ID."""
-        root = ET.fromstring(string)
-        for layer in root:
-            if layer.tag.upper() != "LAYER":
-                # The XML can be <BoundingBox />
+        dom_doc = QDomDocument("gfi")
+        dom_doc.setContent(string)
+        doc_elem = dom_doc.documentElement()
+        layer_elem = doc_elem.firstChildElement()
+        while not layer_elem.isNull():
+            if layer_elem.nodeName().upper() != "LAYER":
+                layer_elem = layer_elem.nextSiblingElement()
                 continue
 
-            if layer.attrib["name"] != layer_name:
+            if layer_elem.attribute("name") != layer_name:
+                layer_elem = layer_elem.nextSiblingElement()
                 continue
 
-            for feature in layer:
-                # feature_id can be int if QgsFeature.id() is used
-                # Otherwise it's string from QgsServerFeatureId
-                if feature.attrib["id"] != str(feature_id):
+            feature_elem = layer_elem.firstChildElement()
+            while not feature_elem.isNull():
+                if feature_elem.attribute("id") != str(feature_id):
+                    feature_elem = feature_elem.nextSiblingElement()
                     continue
 
-                item = feature.find("Attribute[@name='maptip']")
-                if item is not None:
-                    item.attrib["value"] = maptip
-                else:
-                    item = ET.Element("Attribute")
-                    item.attrib["name"] = "maptip"
-                    item.attrib["value"] = maptip
-                    feature.append(item)
+                # We found the feature, now we look for the maptip attribute
+                maptip_found = False
+                attr_elem = feature_elem.firstChildElement()
+                while not attr_elem.isNull():
+                    if attr_elem.attribute("name") == "maptip":
+                        attr_elem.setAttribute("value", maptip)
+                        maptip_found = True
+                        break
+                    attr_elem = attr_elem.nextSiblingElement()
 
-        xml_lines = ET.tostring(root, encoding="utf8", method="xml").decode("utf-8").split("\n")
-        xml_string = "\n".join(xml_lines[1:])
-        return xml_string.strip()
+                if not maptip_found:
+                    attr_elem = dom_doc.createElement("Attribute")
+                    attr_elem.setAttribute("name", "maptip")
+                    attr_elem.setAttribute("value", maptip)
+                    feature_elem.appendChild(attr_elem)
+
+                break
+
+            break
+
+        return dom_doc.toString()
 
     @classmethod
     def feature_list_to_replace(

--- a/tests/test_server_core.py
+++ b/tests/test_server_core.py
@@ -179,27 +179,41 @@ class TestServerCore(unittest.TestCase):
         </GetFeatureInfoResponse>
         """
 
-        response = GetFeatureInfoFilter.append_maptip(string, "qgis_popup", 1, "<b>foo</b>")
+        # build expected unchanged attributes
+        expected_unchanged_attributes = {}
+        gfi = ET.fromstring(string)
+        for attr in gfi[0][0].findall("Attribute"):
+            expected_unchanged_attributes[attr.attrib.get("name")] = attr.attrib.get("value")
 
-        # ElementTree adds a space at the end " />" instead of "/>"
-        # maptip line is un-indented from 1 space, with feature on the same line. !!
-        expected = """<GetFeatureInfoResponse>
-         <Layer name="qgis_popup">
-          <Feature id="1">
-           <Attribute name="OBJECTID" value="2662" />
-           <Attribute name="NAME_0" value="France" />
-           <Attribute name="VARNAME_1" value="Bretaa|Brittany" />
-           <Attribute name="Region" value="Bretagne" />
-           <Attribute name="Shape_Leng" value="18.39336934850" />
-           <Attribute name="Shape_Area" value="3.30646936365" />
-          <Attribute name="maptip" value="&lt;b&gt;foo&lt;/b&gt;" /></Feature>
-         </Layer>
-        </GetFeatureInfoResponse>
-        """
-        self.assertEqual(
-            ET.tostring(ET.fromstring(expected)).decode("utf-8"),
-            ET.tostring(ET.fromstring(response)).decode("utf-8"),
-        )
+        maptip_value = "<b>foo</b>"
+        response = GetFeatureInfoFilter.append_maptip(string, "qgis_popup", 1, maptip_value)
+
+        # Check the response
+        gfi = ET.fromstring(response)
+        self.assertIsNotNone(gfi)
+        self.assertEqual(gfi.tag, "GetFeatureInfoResponse")
+        layer = gfi[0]
+        self.assertIsNotNone(layer)
+        self.assertEqual(layer.tag, "Layer")
+        self.assertEqual(layer.attrib.get("name"), "qgis_popup")
+        feat = layer[0]
+        self.assertIsNotNone(feat)
+        self.assertEqual(feat.tag, "Feature")
+        self.assertEqual(feat.attrib.get("id"), "1")
+        # maptip has been added
+        maptip = feat.find("Attribute[@name='maptip']")
+        self.assertIsNotNone(maptip)
+        self.assertIsNotNone(maptip.attrib.get("value"))
+        self.assertEqual(maptip.attrib.get("value"), maptip_value)
+
+        # Check that the other attributes than maptip are unchanged
+        for attr in feat.findall("Attribute"):
+            name = attr.attrib.get("name")
+            if name == "maptip":
+                continue
+            self.assertIn(name, expected_unchanged_attributes)
+            self.assertEqual(attr.attrib.get("value"), expected_unchanged_attributes.get(name))
+
 
     def test_edit_xml_get_feature_info_with_maptip(self):
         """Test to edit a GetFeatureInfo xml with maptip."""
@@ -219,24 +233,47 @@ class TestServerCore(unittest.TestCase):
         </GetFeatureInfoResponse>
         """
 
-        response = GetFeatureInfoFilter.append_maptip(string, "qgis_popup", 1, "<b>foo</b>")
+        # build expected unchanged attributes
+        # catch initial maptip
+        expected_unchanged_attributes = {}
+        initial_maptip = None
+        gfi = ET.fromstring(string)
+        for attr in gfi[1][0].findall("Attribute"):
+            name = attr.attrib.get("name")
+            if name == "maptip":
+                initial_maptip = attr.attrib.get("value")
+                continue
+            expected_unchanged_attributes[name] = attr.attrib.get("value")
 
-        expected = """<GetFeatureInfoResponse>
-         <BoundingBox minx="0" maxy="1" maxx="1" CRS="EPSG:2154" miny="0"/>
-         <Layer name="qgis_popup">
-          <Feature id="1">
-           <Attribute name="OBJECTID" value="2662" />
-           <Attribute name="NAME_0" value="France" />
-           <Attribute name="VARNAME_1" value="Bretaa|Brittany" />
-           <Attribute name="Region" value="Bretagne" />
-           <Attribute name="Shape_Leng" value="18.39336934850" />
-           <Attribute name="Shape_Area" value="3.30646936365" />
-           <Attribute name="maptip" value="&lt;b&gt;foo&lt;/b&gt;" />
-          </Feature>
-         </Layer>
-        </GetFeatureInfoResponse>
-        """
-        self.assertEqual(
-            ET.tostring(ET.fromstring(expected)).decode("utf-8"),
-            ET.tostring(ET.fromstring(response)).decode("utf-8"),
-        )
+        override_maptip = "<b>foo</b>"
+        response = GetFeatureInfoFilter.append_maptip(string, "qgis_popup", 1, override_maptip)
+
+        # Check the response
+        gfi = ET.fromstring(response)
+        self.assertIsNotNone(gfi)
+        self.assertEqual(gfi.tag, "GetFeatureInfoResponse")
+        bbox = gfi[0]
+        self.assertIsNotNone(bbox)
+        self.assertEqual(bbox.tag, "BoundingBox")
+        layer = gfi[1]
+        self.assertIsNotNone(layer)
+        self.assertEqual(layer.tag, "Layer")
+        self.assertEqual(layer.attrib.get("name"), "qgis_popup")
+        feat = layer[0]
+        self.assertIsNotNone(feat)
+        self.assertEqual(feat.tag, "Feature")
+        self.assertEqual(feat.attrib.get("id"), "1")
+        # maptip has been updated
+        maptip = feat.find("Attribute[@name='maptip']")
+        self.assertIsNotNone(maptip)
+        self.assertIsNotNone(maptip.attrib.get("value"))
+        self.assertNotEqual(maptip.attrib.get("value"), initial_maptip)
+        self.assertEqual(maptip.attrib.get("value"), override_maptip)
+
+        # Check that the other attributes than maptip are unchanged
+        for attr in feat.findall("Attribute"):
+            name = attr.attrib.get("name")
+            if name == "maptip":
+                continue
+            self.assertIn(name, expected_unchanged_attributes)
+            self.assertEqual(attr.attrib.get("value"), expected_unchanged_attributes.get(name))


### PR DESCRIPTION
plugins.qgis.org requires bandit to check severity as medium.

ElementTree has been removed and SQL requests are build to avoid SQL injection.