### PR TITLE
Fix: Invalid widget config for embedded layers

### DIFF
--- a/lizmap_server/get_feature_info.py
+++ b/lizmap_server/get_feature_info.py
@@ -21,7 +21,7 @@ from qgis.PyQt.QtXml import QDomDocument
 
 from .core import find_vector_layer
 from .tools import to_bool, _N
-from .tooltip import Tooltip
+from .tooltip import InvalidWidgetConfig, Tooltip
 
 from . import logger
 
@@ -231,6 +231,13 @@ class GetFeatureInfoFilter(QgsServerFilter):
         # noinspection PyBroadException
         try:
             features = self.feature_list_to_replace(cfg, project, relation_manager, xml, css_framework)
+        except InvalidWidgetConfig as e:
+            logger.warning(
+                f"A field widget config has been invalid: {e}"
+            )
+            # For embedded layer the widget config is empty, so the form could not be
+            # translated to HTML. The default response is returned.
+            return
         except Exception:
             logger.critical(
                 "Error while reading the XML response GetFeatureInfo for project {}, returning default "

--- a/lizmap_server/tooltip.py
+++ b/lizmap_server/tooltip.py
@@ -33,6 +33,9 @@ LOGGER = logging.getLogger("Lizmap")
 SPACES = "  "
 
 
+class InvalidWidgetConfig(Exception):
+    pass
+
 class Tooltip:
     @staticmethod
     def create_popup(html: str) -> str:
@@ -105,6 +108,11 @@ class Tooltip:
                 field_view = Tooltip._generate_external_resource(widget_config, name, fname)
 
             if widget_type == "ValueRelation":
+                if "Layer" not in widget_config:
+                    raise InvalidWidgetConfig(
+                        f"ValueRelation widget config has no Layer property for {name} ({fname})"
+                    )
+
                 if not _N(QgsProject.instance()).mapLayer(widget_config["Layer"]):
                     # Issue #287
                     LOGGER.warning(
@@ -115,6 +123,11 @@ class Tooltip:
                 field_view = Tooltip._generate_represent_value(name)
 
             if widget_type == "RelationReference":
+                if "Relation" not in widget_config:
+                    raise InvalidWidgetConfig(
+                        f"RelationReference widget config has no Relation property for {name} ({fname})"
+                    )
+
                 relation = relation_manager.relation(widget_config["Relation"])
                 referenced_layer = relation.referencedLayer()
 

--- a/tests/test_server_core.py
+++ b/tests/test_server_core.py
@@ -163,6 +163,28 @@ class TestServerCore(unittest.TestCase):
             self.assertEqual(layer, "qgis_popup")
             self.assertEqual(feature, "1")
 
+        string = """<?xml version="1.0" encoding="UTF-8"?>
+         <GetFeatureInfoResponse>
+          <BoundingBox maxy="-0.22573099" minx="-0.83625731" miny="-0.29824561" maxx="-0.21871345" CRS="EPSG:4326"/>
+          <Layer title="child_layer" name="child_layer">
+           <Feature id="1">
+            <Attribute value="1" name="fid"/>
+            <Attribute value="1" name="father_id"/>
+            <Attribute value="Child 1" name="description"/>
+           </Feature>
+           <Feature id="2">
+            <Attribute value="2" name="fid"/>
+            <Attribute value="1" name="father_id"/>
+            <Attribute value="Child 2" name="description"/>
+           </Feature>
+          </Layer>
+         </GetFeatureInfoResponse>
+        """
+
+        for layer, feature in GetFeatureInfoFilter.parse_xml(string):
+            self.assertEqual(layer, "child_layer")
+            self.assertIn(feature, ["1", "2"])
+
     def test_edit_xml_get_feature_info_without_maptip(self):
         """Test to edit a GetFeatureInfo xml without maptip."""
         string = """<GetFeatureInfoResponse>


### PR DESCRIPTION
In the case of an embedded layer, the widget config for RelationReference is empty. The HTML form could not be build, but default popup has to be returned.